### PR TITLE
Add aperture class for computing aperture area

### DIFF
--- a/mocksipipeline/instrument/configuration/moxsi_short.py
+++ b/mocksipipeline/instrument/configuration/moxsi_short.py
@@ -5,12 +5,15 @@ pinhole locations, and number of components.
 import astropy.units as u
 
 from mocksipipeline.instrument.design import InstrumentDesign
+from mocksipipeline.instrument.optics.aperture import CircularAperture
 from mocksipipeline.instrument.optics.configuration import short_design
 from mocksipipeline.instrument.optics.filter import ThinFilmFilter
 from mocksipipeline.instrument.optics.response import Channel
 
 __all__ = [
     'moxsi_short',
+    'moxsi_short_filtergrams',
+    'moxsi_short_spectrogram',
 ]
 
 # Build needed filters
@@ -40,27 +43,34 @@ p_y = (short_design.detector_shape[0] / 2 - 1) / 2 + short_design.detector_shape
 # NOTE: the order here is Cartesian, not (row, column)
 # NOTE: this is 1-indexed
 
+# Set up circular aperture
+pinhole = CircularAperture(44*u.micron)
+
 # Set up filtergrams
 filtergram_1 = Channel(name='filtergram_1',
                        order=0,
                        filters=be_thin,
                        reference_pixel=(p_x, p_y, 0) * u.pix,
-                       design=short_design)
+                       design=short_design,
+                       aperture=pinhole)
 filtergram_2 = Channel(name='filtergram_2',
                        order=0,
                        filters=be_med,
                        reference_pixel=(p_x + window, p_y, 0) * u.pix,
-                       design=short_design)
+                       design=short_design,
+                       aperture=pinhole)
 filtergram_3 = Channel(name='filtergram_3',
                        order=0,
                        filters=be_thick,
                        reference_pixel=(p_x + 2 * window, p_y, 0) * u.pix,
-                       design=short_design)
+                       design=short_design,
+                       aperture=pinhole)
 filtergram_4 = Channel(name='filtergram_4',
                        order=0,
                        filters=[al_oxide, al_thin, polymide],
                        reference_pixel=(p_x + 3 * window, p_y, 0) * u.pix,
-                       design=short_design)
+                       design=short_design,
+                       aperture=pinhole)
 
 # Set up spectrograms
 orders = [-4, -3, -2, -1, 0, 1, 2, 3, 4]
@@ -73,8 +83,14 @@ for order in orders:
                    order=order,
                    filters=[al_thin, al_oxide],
                    reference_pixel=spectrogram_1_refpix,
-                   design=short_design)
+                   design=short_design,
+                   aperture=pinhole)
     spectrograms.append(chan)
 
 # Build instrument configurations
-moxsi_short = InstrumentDesign([filtergram_1, filtergram_2, filtergram_3, filtergram_4] + spectrograms)
+moxsi_short_filtergrams = InstrumentDesign(
+    'short-filtergrams',
+    [filtergram_1, filtergram_2, filtergram_3, filtergram_4]
+)
+moxsi_short_spectrogram = InstrumentDesign('short-dispersed', spectrograms)
+moxsi_short = moxsi_short_filtergrams + moxsi_short_spectrogram

--- a/mocksipipeline/instrument/design.py
+++ b/mocksipipeline/instrument/design.py
@@ -8,4 +8,25 @@ from mocksipipeline.instrument.optics.response import Channel
 
 @dataclasses.dataclass
 class InstrumentDesign:
+    name: str
     channel_list: list[Channel]
+
+    def __add__(self, instrument):
+        if not isinstance(instrument, InstrumentDesign):
+            raise TypeError(f'Addition is not supported with types {type(instrument)}')
+        combined_name = f'{self.name}+{instrument.name}'
+        return InstrumentDesign(combined_name, self.channel_list+instrument.channel_list)
+
+    @property
+    def optical_design(self):
+        # All channels will have the same optical design
+        return self.channel_list[0].design
+
+    def __repr__(self):
+        channel_reprs = '\n'.join(str(c) for c in self.channel_list)
+        return f"""MOXSI Instrument Configuration {self.name}
+                   ------------------------------------------
+{self.optical_design}
+
+{channel_reprs}
+"""

--- a/mocksipipeline/instrument/design.py
+++ b/mocksipipeline/instrument/design.py
@@ -2,6 +2,7 @@
 Class for holding full instrument design
 """
 import dataclasses
+import pprint
 
 from mocksipipeline.instrument.optics.response import Channel
 
@@ -10,6 +11,11 @@ from mocksipipeline.instrument.optics.response import Channel
 class InstrumentDesign:
     name: str
     channel_list: list[Channel]
+
+    def __post_init__(self):
+        # Each channel must have the same optical design
+        if not all([c.design==self.channel_list[0].design for c in self.channel_list]):
+            raise ValueError('All channels must have the same optical design.')
 
     def __add__(self, instrument):
         if not isinstance(instrument, InstrumentDesign):
@@ -25,8 +31,13 @@ class InstrumentDesign:
     def __repr__(self):
         channel_reprs = '\n'.join(str(c) for c in self.channel_list)
         return f"""MOXSI Instrument Configuration {self.name}
-                   ------------------------------------------
-{self.optical_design}
+-------------------------------------------------------------
+
+{pprint.pformat(self.optical_design)}
+
+Channels
+========
+Number of channels: {len(self.channel_list)}
 
 {channel_reprs}
 """

--- a/mocksipipeline/instrument/optics/aperture.py
+++ b/mocksipipeline/instrument/optics/aperture.py
@@ -1,0 +1,72 @@
+"""
+Classes for configuring MOXSI apertures
+"""
+import abc
+
+import astropy.units as u
+import numpy as np
+
+__all__ = ['SlotAperture', 'CircularAperture']
+
+
+class AbstractAperture(abc.ABC):
+    """
+    An abstract base class for defining the geometry of a MOXSI aperture
+    """
+
+    @abc.abstractproperty
+    @u.quantity_input
+    def area(self) -> u.cm**2:
+        ...
+
+
+class SlotAperture(AbstractAperture):
+    """
+    Rectangular MOXSI aperture
+
+    Parameters
+    ----------
+    dimensions: `~astropy.units.Quantity`
+    """
+
+    @u.quantity_input
+    def __init__(self, dimensions: u.cm):
+        self.dimensions = dimensions
+
+    @property
+    @u.quantity_input
+    def area(self) -> u.cm**2:
+        return self.dimensions[0]*self.dimensions[1]
+
+    def __repr__(self):
+        return f"""Rectangular Slot Aperture
+-----------------------------
+dimensions: {self.dimensions}
+area: {self.area}
+"""
+
+
+class CircularAperture(AbstractAperture):
+    """
+    Circular MOXSI aperture
+
+    Parameters
+    ----------
+    diameter: `~astropy.units.Quantity`
+    """
+
+    @u.quantity_input
+    def __init__(self, diameter: u.cm):
+        self.diameter = diameter
+
+    @property
+    @u.quantity_input
+    def area(self) -> u.cm**2:
+        return np.pi * (self.diameter / 2) ** 2
+
+    def __repr__(self):
+        return f"""Circular Aperture
+-------------------------
+diameter: {self.diameter}
+area: {self.area}
+"""

--- a/mocksipipeline/instrument/optics/configuration.py
+++ b/mocksipipeline/instrument/optics/configuration.py
@@ -7,7 +7,9 @@ from .design import OpticalDesign
 
 __all__ = ['short_design', 'long_design', 'short_as_built_design']
 
+
 short_design = OpticalDesign(
+    'short tube',
     focal_length=19.5 * u.cm,
     grating_focal_length=19.5 * u.cm,
     grating_groove_spacing=1 / 5000 * u.mm,
@@ -15,6 +17,7 @@ short_design = OpticalDesign(
 )
 
 long_design = OpticalDesign(
+    'long tube',
     focal_length=25.5 * u.cm,
     grating_focal_length=25.5 * u.cm,
     grating_groove_spacing=1 / 5000 * u.mm,
@@ -22,6 +25,7 @@ long_design = OpticalDesign(
 )
 
 short_as_built_design = OpticalDesign(
+    'short tube as-built',
     focal_length=19.5 * u.cm,
     grating_focal_length=18.21 * u.cm,
     grating_groove_spacing=1 / 5000 * u.mm,

--- a/mocksipipeline/instrument/optics/design.py
+++ b/mocksipipeline/instrument/optics/design.py
@@ -4,7 +4,6 @@ Instrument design configurations
 import dataclasses
 
 import astropy.units as u
-import numpy as np
 
 __all__ = [
     'OpticalDesign',
@@ -18,6 +17,7 @@ class OpticalDesign:
 
     Parameters
     ----------
+    name: `str`
     focal_length: `~astropy.units.Quantity`
         The distance from the pinhole to the detector
     grating_focal_length: `~astropy.units.Quantity`
@@ -36,12 +36,11 @@ class OpticalDesign:
     detector_shape: `tuple`, optional
         Number of pixels in the vertical and horizontal direction
         (in that order) on the detector.
-    pinhole_diameter: `~astropy.units.Quantity`, optional
-        Diameter of the circular pinhole
     camera_gain: `~astropy.units.Quantity`, optional
         Gain of the camera that determines conversion between electrons
         and DN in the detector.
     """
+    name: str
     focal_length: u.Quantity[u.cm]
     grating_focal_length: u.Quantity[u.cm]
     grating_groove_spacing: u.Quantity[u.mm]
@@ -49,11 +48,22 @@ class OpticalDesign:
     pixel_size_x: u.Quantity[u.micron] = 7 * u.micron
     pixel_size_y: u.Quantity[u.micron] = 7 * u.micron
     detector_shape: tuple = (1504, 2000)
-    pinhole_diameter: u.Quantity[u.micron] = 44 * u.micron
     camera_gain: u.Quantity[u.ct / u.electron] = 1.8 * u.ct / u.electron
 
-    @property
-    @u.quantity_input
-    def pinhole_area(self) -> u.cm ** 2:
-        "Area for a circular pinhole"
-        return np.pi * (self.pinhole_diameter / 2) ** 2
+    def __repr__(self):
+        return f"""MOXSI Optical Design {self.name}
+=========================================
+focal length: {self.focal_length}
+
+Grating
+-------
+focal length: {self.grating_focal_length}
+groove spacing: {self.grating_groove_spacing}
+roll angle {self.grating_roll_angle}
+
+Detector
+--------
+pixel size: x={self.pixel_size_x}, y={self.pixel_size_y}
+shape: {self.detector_shape}
+camera gain: {self.camera_gain}
+"""

--- a/mocksipipeline/instrument/optics/response.py
+++ b/mocksipipeline/instrument/optics/response.py
@@ -62,7 +62,7 @@ Wavelength range: [{self.wavelength_min}, {self.wavelength_max}]
 Spectral plate scale: {self.spectral_plate_scale}
 Spatial plate scale: {self.spatial_plate_scale}
 Reference pixel: {self.reference_pixel}
-{self.aperture}
+aperture: {self.aperture}
 """
 
     @property
@@ -99,40 +99,17 @@ Reference pixel: {self.reference_pixel}
     @property
     @u.quantity_input
     def spatial_plate_scale(self) -> u.Unit('arcsec / pix'):
-        pixel_size = u.Quantity([self.design.pixel_size_x, self.design.pixel_size_y]) / u.pixel
-        return (pixel_size / self.design.focal_length).decompose() * u.radian
+        return self.design.spatial_plate_scale
 
     @property
     @u.quantity_input
     def pixel_solid_angle(self) -> u.Unit('steradian / pix'):
-        """
-        This is the solid angle per pixel
-        """
-        area = (self.spatial_plate_scale[0] * u.pix) * (self.spatial_plate_scale[1] * u.pix)
-        return area / u.pix
+        return self.design.pixel_solid_angle
 
     @property
     @u.quantity_input
     def spectral_plate_scale(self) -> u.Unit('Angstrom / pix'):
-        r"""
-        The spectral plate scale is computed as,
-
-        .. math::
-
-            \Delta\lambda = \frac{d(\Delta x\|\cos{\gamma}\| + \Delta y\|\sin{\gamma}\|)}{f^\prime}
-
-        where :math:`\gamma` is the grating roll angle and :math`\Delta x,\Delta y`
-        are the spatial plate scales, :math:`d` is the groove spacing of the grating, and
-        :math:`f^\prime` is the distance between the grating and the detector.
-        """
-        # NOTE: Purposefully not dividing by the spectral order here as this is
-        # meant to only represent the first order spectral plate scale due to how we
-        # express the wavelength axis in the WCS as a "dummy" third axis. The additional dispersion
-        # at orders > 1 is handled by the spectral order term in the PC_ij matrix.
-        eff_pix_size = (self.design.pixel_size_x * np.fabs(np.cos(self.design.grating_roll_angle)) +
-                        self.design.pixel_size_y * np.fabs(np.sin(self.design.grating_roll_angle))) / u.pix
-        return (self.design.grating_groove_spacing *
-                (eff_pix_size / self.design.grating_focal_length).decompose())
+        return self.design.spectral_plate_scale
 
     @property
     def detector_shape(self):

--- a/mocksipipeline/instrument/optics/response.py
+++ b/mocksipipeline/instrument/optics/response.py
@@ -22,24 +22,28 @@ class Channel:
     Parameters
     ----------
     name: `str`
-        Name of the filtergram. This determines the position of the image on the detector.
-    order: `int`, optional
-        Spectral order for the channel. By default, this is 0.
-    optical_design: `~mocksipipeline.detector.design.OpticalDesign`, optional
-        Instrument optical design. If not specified, will default to
-        `~mocksipipeline.detector.design.nominal_design`
+        Name of the channel. If this is a filtergram channel, the word "filtergram"
+        should appear somewhere in it. This is used to set the grating efficiency
+        to 1 since the filtergram images do not pass through the dispersive grating.
     filters: `~mocksipipeline.detector.filter.ThinFilmFilter` or list, optional
         If multiple filters are specified, the filter transmission is computed as
         the product of the transmissivities. If not specified, fall back to default
         filters for a particular channel.
+    order: `int`, optional
+        Spectral order for the channel. By default, this is 0.
+    design: `~mocksipipeline.detector.design.OpticalDesign`, optional
+        Instrument optical design
+    aperture: `~mocksipipeline.instrument.optics.aperture.AbstractAperture`
+        Aperture model used for calculating geometrical area
     reference_pixel: `tuple`,
         Pixel location of solar image in cartesian coordinates
     """
 
-    def __init__(self, name, filters, order, design, reference_pixel, **kwargs):
+    def __init__(self, name, filters, order, design, aperture, reference_pixel, **kwargs):
         self.name = name
         self.spectral_order = order
         self.design = design
+        self.aperture = aperture
         self.xrt_table_name = 'Chantler'  # Intentionally hardcoding this for now
         self.filters = filters
         self.grating_file = kwargs.pop('grating_file', None)
@@ -58,8 +62,8 @@ Wavelength range: [{self.wavelength_min}, {self.wavelength_max}]
 Spectral plate scale: {self.spectral_plate_scale}
 Spatial plate scale: {self.spatial_plate_scale}
 Reference pixel: {self.reference_pixel}
+{self.aperture}
 """
-
 
     @property
     def filters(self):
@@ -201,7 +205,7 @@ Reference pixel: {self.reference_pixel}
     @property
     @u.quantity_input
     def geometrical_collecting_area(self) -> u.cm ** 2:
-        return self.design.pinhole_area
+        return self.aperture.area
 
     @property
     @u.quantity_input

--- a/mocksipipeline/instrument/optics/tests/test_channel.py
+++ b/mocksipipeline/instrument/optics/tests/test_channel.py
@@ -20,11 +20,16 @@ def design():
     return moxsi_short.channel_list[0].design
 
 
+@pytest.fixture
+def aperture():
+    return moxsi_short.channel_list[0].aperture
+
+
 @pytest.mark.parametrize(
         ('name', 'order'),
         [(f'filtergram_{i}', 0) for i in range(1, 5)]+[('spectrogram_1', i) for i in range(-4, 5, 1)])
-def test_channel_creation(name, order, filters, design):
-    chan = Channel(name, filters, order, design, (0,0))
+def test_channel_creation(name, order, filters, design, aperture):
+    chan = Channel(name, filters, order, design, aperture, (0,0))
     assert isinstance(chan, Channel)
 
 

--- a/mocksipipeline/inversion/response_matrix.py
+++ b/mocksipipeline/inversion/response_matrix.py
@@ -73,7 +73,7 @@ def compute_response_matrix(spectral_table, instrument_design, extent=2500*u.arc
     # Compute the effective spectra
     spectra_eff = [compute_effective_spectra(spectral_table, chan) for chan in instrument_design.channel_list]
     # Compute the WCS that we will invert into and that we will invert from
-    plate_scale = instrument_design.channel_list[0].spatial_plate_scale[::-1]
+    plate_scale = instrument_design.optical_design.spatial_plate_scale[::-1]
     shape = tuple(np.ceil((extent / plate_scale).to_value('pix')).astype(int))
     # NOTE: I do not think it matters what this observer is, because ultimately this is just a
     # pixel-to-pixel transformation and thus all of the celestial transforms should factor out.


### PR DESCRIPTION
This PR adds a new abstract base class `AbstractAperture` as well as two additional concrete classes `CircularAperture` and `SlotAperture`. As a result, the `Channel` class now takes in an instance of this aperture class and it uses to compute the geometrical area such that the aperture can be any arbitrary shape. The `OpticalDesign` no longer takes in the pinhole diameter.

Additionally, this PR adds reprs for optical and instrument designs and also adds a method for combining instrument designs.