### PR TITLE
Adapting the pipeline for the slot overlappogram

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,11 +9,33 @@ observations from 2022-03-30 17:55 with coronal abundances
 
 ```shell
 cd pipeline/workflow
-$ snakemake ../results/2022-03-30T17:55_sun_coronal_1992_feldman_ext_all/detector_images/all_components.fits --config root_dir='../results' obstime='2022-03-30T17:55' --cores 1
+$ snakemake ../results/flare-run/detector_images/all_components.fits \
+            --config output_dir='flare-run' \
+                     obstime='2022-03-30T17:55' \
+                     instrument_design='moxsi_slot' \
+            --cores 1
 ```
 
 If you want to run the pipeline, but only rerun the steps if the needed files are missing (i.e. skip the checks on if any scripts have changed since the previous run),
 
 ```shell
-$ snakemake ../results/2022-03-30T17:55_sun_coronal_1992_feldman_ext_all/detector_images/all_components.fits --config root_dir='../results' obstime='2022-03-30T17:55' --cores 1 --rerun-triggers mtime
+$ snakemake ../results/flare-run/detector_images/all_components.fits
+            --config output_dir='flare-run' \
+                     obstime='2022-03-30T17:55'
+                     instrument_design='moxsi_slot' \
+            --cores 1 \
+            --rerun-triggers mtime
+```
+
+If you want to produce a 1 s image in units of photons rather than DN,
+
+```shell
+$ snakemake ../results/ar-run/detector_images/all_components.fits \
+            --config output_dir='ar-run' \
+                     obstime='2020-11-09T17:59:57' \
+                     exposure_time=1 \
+                     cadence=1 \
+                     instrument_design='moxsi_slot' \
+                     convert_to_dn='False' \
+            --cores 1
 ```

--- a/mocksipipeline/instrument/configuration/moxsi_slot.py
+++ b/mocksipipeline/instrument/configuration/moxsi_slot.py
@@ -33,8 +33,14 @@ al_oxide = ThinFilmFilter(elements=['Al', 'O'], quantities=[2, 3], thickness=7.5
 
 # Set up apertures
 pinhole = CircularAperture(44*u.micron)
+# NOTE: center-to-center distance is set such that the slot area is 10 times the pinhole area
 slot = SlotAperture(diameter=pinhole.diameter,
                     center_to_center_distance=9*np.pi*pinhole.diameter/4)
+# FIXME: Adding an additional FWHM parameter here to be used in the PSF calculation
+# in the pipeline. In general, these need an actual PSF kernel that should be implemented
+# on the aperture object rather than just a single numerical attribute
+pinhole.psf_fwhm = [40, 40] * u.arcsec
+slot.psf_fwhm = pinhole.psf_fwhm * np.array([(slot.center_to_center_distance/slot.diameter).decompose(), 1])
 
 # Set up reference pixels
 detector_center = np.array(short_design.detector_shape)[::-1] / 2

--- a/mocksipipeline/instrument/design.py
+++ b/mocksipipeline/instrument/design.py
@@ -49,6 +49,9 @@ class InstrumentDesign:
         combined_name = f'{self.name}+{instrument.name}'
         return InstrumentDesign(combined_name, self.channel_list+instrument.channel_list)
 
+    def __getitem__(self, value):
+        return {f'{c.name}_{c.spectral_order}': c for c in self.channel_list}[value]
+
     @property
     def optical_design(self):
         # All channels will have the same optical design

--- a/mocksipipeline/modeling.py
+++ b/mocksipipeline/modeling.py
@@ -9,7 +9,7 @@ import ndcube
 import numpy as np
 from astropy.convolution import Gaussian1DKernel, convolve
 from astropy.stats import gaussian_fwhm_to_sigma
-from astropy.wcs.utils import pixel_to_pixel, wcs_to_celestial_frame
+from astropy.wcs.utils import pixel_to_pixel
 from ndcube.extra_coords import QuantityTableCoordinate
 from overlappy.util import strided_array
 from scipy.interpolate import interp1d
@@ -96,8 +96,9 @@ def convolve_with_response(cube, channel, electrons=True, include_gain=False):
     return ndcube.NDCube(data_interp, wcs=new_wcs, meta=meta, unit=unit)
 
 
-def project_spectral_cube(spec_cube,
+def project_spectral_cube(instr_cube,
                           channel,
+                          observer,
                           dt=1*u.s,
                           interval=20*u.s,
                           convert_to_dn=False,
@@ -116,9 +117,6 @@ def project_spectral_cube(spec_cube,
         If True, sum counts in DN. Poisson sampling will still be done
         in photon space
     """
-    # Convert to instrument units
-    observer = wcs_to_celestial_frame(spec_cube.wcs).observer
-    instr_cube = convolve_with_response(spec_cube, channel, electrons=False, include_gain=False)
     # Sample distribution
     lam = (instr_cube.data * instr_cube.unit * u.pix * dt).to_value('photon')
     if chunks is None:

--- a/mocksipipeline/net.py
+++ b/mocksipipeline/net.py
@@ -76,7 +76,7 @@ class XRTSynopticClient(GenericClient):
 
     def _scrape_fits_files_for_timerange(self, matchdict):
         # TODO: add comment about why we have to do this
-        fits_base_url = r'http://solar.physics.montana.edu/HINODE/XRT/SCIA/synop_official/'
+        fits_base_url = r'https://xrt.cfa.harvard.edu/data_products/Level2_Synoptics/'
         fits_pattern = r'%Y/%m/%d/H%H00/comp_XRT%Y%m%d_%H%M%S.(\d){1}.fits'
         fits_scraper = Scraper(fits_base_url+fits_pattern, regex=True)
         fits_urls = fits_scraper.filelist(TimeRange(matchdict['Start Time'], b=matchdict['End Time']))

--- a/pipeline/config/config.yml
+++ b/pipeline/config/config.yml
@@ -1,12 +1,8 @@
-root_dir:
+root_dir: '../results'
 obstime:
 obstime_window: 7200
 spectral_table: 'sun_coronal_1992_feldman_ext_all'
-plate_scale_x: 7.4  # in arcsec / pix
-plate_scale_y: 7.4  # in arcsec / pix
-full_disk_extent: 2500  # in arcsec
 percent_error: 20  # error estimate on input DEM images
-psf_fwhm: 40  # in arcsec
 log_t_left_edge: 5.5
 log_t_right_edge: 7.5
 delta_log_t: 0.1

--- a/pipeline/workflow/Snakefile
+++ b/pipeline/workflow/Snakefile
@@ -1,37 +1,20 @@
 import pathlib
 
+import mocksipipeline.instrument.configuration
+
 configfile: "../config/config.yml"
 
-root_dir = pathlib.Path(config['root_dir']) / f'{config["obstime"]}_{config["spectral_table"]}'
+root_dir = pathlib.Path(config['root_dir']) / config['output_dir']
+instrument_design = getattr(mocksipipeline.instrument.configuration, config["instrument_design"])
 
 XRT_FILTERS = ['Be-thin:Open',]
 AIA_FILTERS = ['94', '131', '171', '193', '211', '335']
-FILTERGRAM_NAMES = [
-    'filtergram_1',
-    'filtergram_2',
-    'filtergram_3',
-    'filtergram_4',
-]
-SPECTROGRAM_NAMES = [
-    'spectrogram_1',
-    # 'specttrogram_2',  # TODO: Implement rectangular spectrogram
-]
-SPECTRAL_ORDERS = [
-    -4,
-    -3,
-    -2,
-    -1,
-    0,
-    1,
-    2,
-    3,
-    4,
-]
+CHANNEL_NAMES = [f'{c.name}_{c.spectral_order}' for c in instrument_design.channel_list]
+
 
 rule sum_components:
     input:
-        expand(root_dir / 'detector_images' / '{channel}_0.fits', channel=FILTERGRAM_NAMES),
-        expand(root_dir / 'detector_images' / '{channel}_{order}.fits', channel=SPECTROGRAM_NAMES, order=SPECTRAL_ORDERS)
+        expand(root_dir / 'detector_images' / '{channel_name}.fits', channel_name=CHANNEL_NAMES)
     output:
         root_dir / 'detector_images' / 'all_components.fits'
     script:
@@ -41,10 +24,9 @@ rule calculate_detector_images:
     input:
         root_dir / 'spectral_cube.fits'
     output:
-        root_dir / 'detector_images' / '{channel}_{order}.fits'
+        root_dir / 'detector_images' / '{channel_name}.fits'
     params:
-        channel=lambda wildcards: wildcards.channel,
-        order=lambda wildcards: wildcards.order
+        channel_name=lambda wildcards: wildcards.channel_name
     script:
         "scripts/project_intensity_cubes.py"
 

--- a/pipeline/workflow/scripts/calculate_dem.py
+++ b/pipeline/workflow/scripts/calculate_dem.py
@@ -1,6 +1,8 @@
 """
 Script to compute DEM cube constrained by EUV and SXR images.
 """
+import pathlib
+
 import aiapy.response
 import astropy.units as u
 import ndcube
@@ -176,7 +178,12 @@ if __name__ == '__main__':
         delta_log_t,
     ) * u.K
     # Read in spectral table
-    spectral_table = get_spectral_tables()[snakemake.config['spectral_table']]
+    spectral_table_name = snakemake.config['spectral_table']
+    if pathlib.Path(spectral_table_name).is_file():
+        from synthesizAR.atomic.idl import read_spectral_table
+        spectral_table = read_spectral_table(spectral_table_name)
+    else:
+        spectral_table = get_spectral_tables()[spectral_table_name]
     # Compute temperature response functions
     temperature_kernel = 10**np.arange(5, 8, 0.05) * u.K
     kernels = calculate_response_kernels(collection,

--- a/pipeline/workflow/scripts/calculate_spectral_cube.py
+++ b/pipeline/workflow/scripts/calculate_spectral_cube.py
@@ -1,3 +1,5 @@
+import pathlib
+
 import sunpy.io._fits as sunpy_fits
 
 from mocksipipeline.spectral import calculate_intensity, get_spectral_tables
@@ -5,7 +7,12 @@ from mocksipipeline.util import read_cube_with_xarray
 
 if __name__ == '__main__':
     em_cube = read_cube_with_xarray(snakemake.input[0], 'temperature', 'phys.temperature')
-    spectral_table = get_spectral_tables()[snakemake.config['spectral_table']]
+    spectral_table_name = snakemake.config['spectral_table']
+    if pathlib.Path(spectral_table_name).is_file():
+        from synthesizAR.atomic.idl import read_spectral_table
+        spectral_table = read_spectral_table(spectral_table_name)
+    else:
+        spectral_table = get_spectral_tables()[spectral_table_name]
     # NOTE: the FITS WCS info is stored in the NDCube metadata
     spectral_cube = calculate_intensity(em_cube, spectral_table, em_cube.meta)
     sunpy_fits.write(snakemake.output[0],

--- a/pipeline/workflow/scripts/project_intensity_cubes.py
+++ b/pipeline/workflow/scripts/project_intensity_cubes.py
@@ -14,6 +14,11 @@ def apply_psf(cube, channel):
     # FIXME: This is just a placeholder PSF calculation. Need to implement an actual
     # convolution with a model PSF that more accurately captures the effect of the slot
     # on the spatial resolution
+    # NOTE: By applying the PSF on the spectral cube, we are assuming that the pixel grid
+    # here is aligned with the pixel grid of the detector. The PSF FWHM has been carefully
+    # constructed to account for this. In general, we should figure out a way to define
+    # the PSF kernel on the zeroth order detector grid and transform it to this coordinate
+    # system.
     psf_sigma = channel.aperture.psf_fwhm * gaussian_fwhm_to_sigma / channel.spatial_plate_scale
     _ = scipy.ndimage.gaussian_filter(cube.data,
                                       psf_sigma.to_value('pixel')[::-1],
@@ -34,7 +39,7 @@ if __name__ == '__main__':
     # Read in spectral cube
     spec_cube = read_data_cube(snakemake.input[0])
     # Convolve with instrument response function
-    instr_cube = convolve_with_response(spec_cube, channel, electrons=False, include_gain=False)
+    instr_cube = convolve_with_response(spec_cube, channel, include_gain=False)
     # Apply channel-dependent PSF
     # PSF convolution calculation goes here
     instr_cube = apply_psf(instr_cube, channel)

--- a/pipeline/workflow/scripts/project_intensity_cubes.py
+++ b/pipeline/workflow/scripts/project_intensity_cubes.py
@@ -1,25 +1,47 @@
 import astropy.units as u
+import scipy.ndimage
+from astropy.stats import gaussian_fwhm_to_sigma
+from astropy.wcs.utils import wcs_to_celestial_frame
 from overlappy.io import write_overlappogram
 
-from mocksipipeline.detector import project_spectral_cube
-from mocksipipeline.instrument.optics.response import Channel
+import mocksipipeline.instrument.configuration
+from mocksipipeline.modeling import (convolve_with_response,
+                                     project_spectral_cube)
 from mocksipipeline.util import read_data_cube
+
+
+def apply_psf(cube, channel):
+    # FIXME: This is just a placeholder PSF calculation. Need to implement an actual
+    # convolution with a model PSF that more accurately captures the effect of the slot
+    # on the spatial resolution
+    psf_sigma = channel.aperture.psf_fwhm * gaussian_fwhm_to_sigma / channel.spatial_plate_scale
+    _ = scipy.ndimage.gaussian_filter(cube.data,
+                                      psf_sigma.to_value('pixel')[::-1],
+                                      axes=(1,2),
+                                      output=cube.data)
+    return cube
+
 
 if __name__ == '__main__':
     # Read in config options
     dt = float(snakemake.config['exposure_time']) * u.s
     interval = float(snakemake.config['cadence']) * u.s
     convert_to_dn = bool(snakemake.config['convert_to_dn'])
-    # Create channel object
-    channel_name = snakemake.params.channel
-    spectral_order = int(snakemake.params.order)
-    # TODO: add ability to specify different designs
-    channel = Channel(channel_name, order=spectral_order)
+    # Load instrument configuration
+    instrument_design = getattr(mocksipipeline.instrument.configuration, snakemake.config['instrument_design'])
+    # Select channel
+    channel = instrument_design[snakemake.params.channel_name]
     # Read in spectral cube
     spec_cube = read_data_cube(snakemake.input[0])
+    # Convolve with instrument response function
+    instr_cube = convolve_with_response(spec_cube, channel, electrons=False, include_gain=False)
+    # Apply channel-dependent PSF
+    # PSF convolution calculation goes here
+    instr_cube = apply_psf(instr_cube, channel)
     # Remap spectral cube
-    det_cube = project_spectral_cube(spec_cube,
+    det_cube = project_spectral_cube(instr_cube,
                                      channel,
+                                     wcs_to_celestial_frame(spec_cube.wcs).observer,
                                      dt=dt,
                                      interval=interval,
                                      convert_to_dn=convert_to_dn)


### PR DESCRIPTION
Fixes #28 

This PR makes some changes to the pipeline to accommodate  the addition of the second overlappogram. The main change is the move of the application of the PSF from the DEM/images to being done on the instrument cube just before projecting down to the detector.

There are still some major TODOs regarding the treatment of the PSF. Currently, the application of the PSF is still just being done with a Gaussian filter. In the slot case, the sigma in the vertical direction is $D_{cc}/d$ times wider (where $D_{cc}$ is the center-to-center distance of the slot). In reality, we should be building a kernel (using something like a tophat  function) for the slot case. 