### PR TITLE
Include "jitter" due to PSF and charge spreading

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Exclude the PSF files because they are too big and also fast to calculate
+mocksipipeline/instrument/optics/data/psf*.nc
+
 # Template specific
 *.pdf
 mocksipipeline/version.py

--- a/mocksipipeline/instrument/configuration/__init__.py
+++ b/mocksipipeline/instrument/configuration/__init__.py
@@ -1,2 +1,3 @@
+from .moxsi_cdr import *
 from .moxsi_short import *
 from .moxsi_slot import *

--- a/mocksipipeline/instrument/configuration/moxsi_cdr.py
+++ b/mocksipipeline/instrument/configuration/moxsi_cdr.py
@@ -1,0 +1,110 @@
+"""
+Configurations for MOXSI as of CDR
+"""
+import astropy.units as u
+import numpy as np
+
+from mocksipipeline.instrument.design import InstrumentDesign
+from mocksipipeline.instrument.optics.aperture import (CircularAperture,
+                                                       SlotAperture)
+from mocksipipeline.instrument.optics.configuration import \
+    short_as_built_design
+from mocksipipeline.instrument.optics.filter import ThinFilmFilter
+from mocksipipeline.instrument.optics.response import (ALLOWED_SPECTRAL_ORDERS,
+                                                       Channel)
+
+__all__ = [
+    'moxsi_cdr',
+    'moxsi_cdr_filtergrams',
+    'moxsi_cdr_spectrogram_pinhole',
+    'moxsi_cdr_spectrogram_slot',
+]
+
+# Build needed filters
+table = 'Chantler'
+be_thin = ThinFilmFilter('Be', thickness=11.5*u.micron, xrt_table=table)
+be_med = ThinFilmFilter('Be', thickness=29.8*u.micron, xrt_table=table)
+be_thick = ThinFilmFilter('Be', thickness=350*u.micron, xrt_table=table)
+polymide = ThinFilmFilter(elements=['C', 'H', 'N', 'O'],
+                          quantities=[22, 10, 2, 5],
+                          density=1.43*u.g/u.cm**3,
+                          thickness=1*u.micron,
+                          xrt_table=table)
+al_thin = ThinFilmFilter(elements='Al', thickness=142.5*u.nm, xrt_table=table)
+al_oxide = ThinFilmFilter(elements=['Al', 'O'], quantities=[2, 3], thickness=7.5*u.nm, xrt_table=table)
+
+# Set up apertures
+circular = CircularAperture(44*u.micron)
+# NOTE: center-to-center distance is set such that the slot area is 10 times the pinhole area
+slot = SlotAperture(diameter=circular.diameter,
+                    center_to_center_distance=9*np.pi*circular.diameter/4)
+
+# Set up reference pixels
+detector_center = np.array(short_as_built_design.detector_shape)[::-1] / 2
+# Values pulled from mechanical drawing 1/11/24
+filtergram_y = 3.51 * u.mm
+filtergram_x = (np.arange(4) * 3.32 - 1.5 * 3.32) * u.mm
+slot_y = 3.43 * u.mm
+filtergram_ref_pix = [
+    tuple(np.array([x / short_as_built_design.pixel_size_x,
+                    filtergram_y / short_as_built_design.pixel_size_y]) + detector_center)
+    for x in filtergram_x
+]
+pinhole_ref_pix = tuple(detector_center)
+slot_ref_pix = tuple(detector_center - [0, slot_y / short_as_built_design.pixel_size_y])
+
+# Set up filtergrams
+filtergram_1 = Channel(name='filtergram_1',
+                       order=0,
+                       filters=be_thin,
+                       reference_pixel=(filtergram_ref_pix[0]+(0,))*u.pix,
+                       design=short_as_built_design,
+                       aperture=circular)
+filtergram_2 = Channel(name='filtergram_2',
+                       order=0,
+                       filters=be_med,
+                       reference_pixel=(filtergram_ref_pix[1]+(0,))*u.pix,
+                       design=short_as_built_design,
+                       aperture=circular)
+filtergram_3 = Channel(name='filtergram_3',
+                       order=0,
+                       filters=be_thick,
+                       reference_pixel=(filtergram_ref_pix[2]+(0,))*u.pix,
+                       design=short_as_built_design,
+                       aperture=circular)
+filtergram_4 = Channel(name='filtergram_4',
+                       order=0,
+                       filters=[al_oxide, al_thin, polymide],
+                       reference_pixel=(filtergram_ref_pix[3]+(0,))*u.pix,
+                       design=short_as_built_design,
+                       aperture=circular)
+
+# Set up spectrograms
+spectrograms_pinhole = []
+spectrograms_slot = []
+for order in ALLOWED_SPECTRAL_ORDERS:
+    spectrograms_pinhole.append(
+        Channel(name='spectrogram_pinhole',
+                order=order,
+                filters=[al_thin, al_oxide],
+                reference_pixel=(pinhole_ref_pix+(0,))*u.pix,
+                design=short_as_built_design,
+                aperture=circular)
+    )
+    spectrograms_slot.append(
+        Channel(name='spectrogram_slot',
+                order=order,
+                filters=[al_thin, al_oxide],
+                reference_pixel=(slot_ref_pix+(0,))*u.pix,
+                design=short_as_built_design,
+                aperture=slot)
+    )
+
+# Build instrument configurations
+moxsi_cdr_filtergrams = InstrumentDesign(
+    'cdr-filtergrams',
+    [filtergram_1, filtergram_2, filtergram_3, filtergram_4]
+)
+moxsi_cdr_spectrogram_pinhole = InstrumentDesign('cdr-dispersed-pinhole', spectrograms_pinhole)
+moxsi_cdr_spectrogram_slot = InstrumentDesign('cdr-dispersed-slot', spectrograms_slot)
+moxsi_cdr = moxsi_cdr_filtergrams + moxsi_cdr_spectrogram_pinhole + moxsi_cdr_spectrogram_slot

--- a/mocksipipeline/instrument/configuration/moxsi_slot.py
+++ b/mocksipipeline/instrument/configuration/moxsi_slot.py
@@ -37,11 +37,6 @@ pinhole = CircularAperture(44*u.micron)
 # NOTE: center-to-center distance is set such that the slot area is 10 times the pinhole area
 slot = SlotAperture(diameter=pinhole.diameter,
                     center_to_center_distance=9*np.pi*pinhole.diameter/4)
-# FIXME: Adding an additional FWHM parameter here to be used in the PSF calculation
-# in the pipeline. In general, these need an actual PSF kernel that should be implemented
-# on the aperture object rather than just a single numerical attribute
-pinhole.psf_fwhm = [40, 40] * u.arcsec
-slot.psf_fwhm = pinhole.psf_fwhm * np.array([(slot.center_to_center_distance/slot.diameter).decompose(), 1])
 
 # Set up reference pixels
 detector_center = np.array(short_design.detector_shape)[::-1] / 2

--- a/mocksipipeline/instrument/design.py
+++ b/mocksipipeline/instrument/design.py
@@ -1,11 +1,13 @@
 """
 Class for holding full instrument design
 """
+import copy
 import dataclasses
 import pprint
 
 import astropy.units as u
 import matplotlib.pyplot as plt
+import numpy as np
 from astropy.coordinates import SkyCoord
 from sunpy.coordinates import get_earth
 from sunpy.coordinates.utils import get_limb_coordinates
@@ -18,24 +20,53 @@ class InstrumentDesign:
     name: str
     channel_list: list[Channel]
 
-    def plot_detector_layout(self, observer=None, wavelength=0*u.AA, color=None):
+    def plot_detector_layout(self, observer=None, wavelength=0*u.AA, color=None, **kwargs):
+        """
+        Plot position of solar limb on detector for all components at a given wavelength.
+
+        Parameters
+        ----------
+        observer: `~astropy.coordinates.SkyCoord`, optional
+            Location of the observer used to get the limb position. Defaults to Earth.
+        wavelength: `~astropy.Quantity`, optional
+            Wavelength of the images to plot. This determines the degree of dispersion
+        color: `str`, optional
+        """
         if observer is None:
             observer = get_earth('2020-01-01')
-        limb_coord = get_limb_coordinates(observer, resolution=100)
+        limb_coord = get_limb_coordinates(observer, resolution=kwargs.get('resolution', 500))
         origin = SkyCoord(Tx=0*u.arcsec, Ty=0*u.arcsec, frame='helioprojective', observer=observer)
 
-        fig = plt.figure()
+        fig = plt.figure(figsize=kwargs.get('figsize'))
         ax = fig.add_subplot()
-        colors = {i: f'C{i}' for i in range(12)}
+        colors = {i: f'C{i-1}' for i in range(1,12)}
+        colors[0] = 'k'  # Specifically call out the 0th order images
         for channel in self.channel_list:
             _wcs = channel.get_wcs(observer)
             px, py, _ = _wcs.world_to_pixel(limb_coord, wavelength)
+            px_o, py_o, _ = _wcs.world_to_pixel(origin, wavelength)
             _color=colors[abs(channel.spectral_order)] if color is None else color
-            ax.plot(px, py, ls='-', color=_color)
-            px, py, _ = _wcs.world_to_pixel(origin, wavelength)
-            ax.plot(px, py, ls='', marker='x', color=_color)
+            # Approximate effect of PSF as elliptical distortions of circular limb
+            extent_x = (px.max() - px.min()) * self.optical_design.pixel_size_x
+            extent_y = (py.max() - py.min()) * self.optical_design.pixel_size_y
+            psf_extent_x = copy.copy(channel.aperture.diameter)
+            psf_extent_y = copy.copy(channel.aperture.diameter)
+            if hasattr(channel.aperture, 'center_to_center_distance'):
+                psf_extent_y = psf_extent_y + channel.aperture.center_to_center_distance
+            stretch = np.array([[(psf_extent_x + extent_x) / extent_x, 0],
+                                [0, (psf_extent_y + extent_y) / extent_y]])
+            delta_px, delta_py = np.dot(stretch, np.array([px-px_o, py-py_o]))
+            # Plot undistorted limb
+            ax.plot(px, py, ls=':', color=_color)
+            # Plot distorted limb
+            ax.plot(px_o + delta_px, py_o + delta_py, ls='-', color=_color)
+            # Plot center position
+            ax.plot(px_o, py_o, ls='', marker='x', color=_color)
         ax.set_xlim(0, self.optical_design.detector_shape[1])
         ax.set_ylim(0, self.optical_design.detector_shape[0])
+        ax.set_aspect('equal')
+        if kwargs.get('return_figure', False):
+            return fig
         plt.show()
 
     def __post_init__(self):
@@ -50,7 +81,18 @@ class InstrumentDesign:
         return InstrumentDesign(combined_name, self.channel_list+instrument.channel_list)
 
     def __getitem__(self, value):
-        return {f'{c.name}_{c.spectral_order}': c for c in self.channel_list}[value]
+        # There are two ways to index an Instrument configuration
+        # 1. Through the string designation of the channel. This returns a single channel
+        # 2. Through some slice of the channel list. This will return another instrument config
+        #    or possibly a single channel
+        if isinstance(value, str):
+            return {f'{c.name}_{c.spectral_order}': c for c in self.channel_list}[value]
+        else:
+            new_channel_list = self.channel_list[value]
+            if isinstance(new_channel_list, type(self.channel_list[0])):
+                return new_channel_list
+            else:
+                return type(self)(self.name, new_channel_list)
 
     @property
     def optical_design(self):

--- a/mocksipipeline/instrument/design.py
+++ b/mocksipipeline/instrument/design.py
@@ -26,7 +26,7 @@ class InstrumentDesign:
 
         fig = plt.figure()
         ax = fig.add_subplot()
-        colors = {i: f'C{i}' for i in range(5)}
+        colors = {i: f'C{i}' for i in range(12)}
         for channel in self.channel_list:
             _wcs = channel.get_wcs(observer)
             px, py, _ = _wcs.world_to_pixel(limb_coord, wavelength)

--- a/mocksipipeline/instrument/optics/aperture.py
+++ b/mocksipipeline/instrument/optics/aperture.py
@@ -46,13 +46,13 @@ class SlotAperture(AbstractAperture):
     def area(self) -> u.cm ** 2:
         return np.pi * (self.diameter / 2) ** 2 + self.diameter * self.center_to_center_distance
 
-    @property
     def mask(self, oversample=8):
         pinhole_diameter = self.diameter
         center2center_distance = self.center_to_center_distance
 
-        aperture_size = center2center_distance * 1.2
-        x = np.linspace(-aperture_size/2, aperture_size / 2, num=int((aperture_size*oversample).value), endpoint=True)
+        aperture_size = (center2center_distance + pinhole_diameter) * 1.05
+        x = np.linspace(-aperture_size / 2, aperture_size / 2, num=int((aperture_size * oversample).value),
+                        endpoint=True)
         x, y = np.meshgrid(x, x)
 
         # shift coordinate system
@@ -118,8 +118,7 @@ class CircularAperture(AbstractAperture):
     def area(self) -> u.cm ** 2:
         return np.pi * (self.diameter / 2) ** 2
 
-    @property
-    def mask(self, oversample=16) -> xarray.DataArray:
+    def mask(self, oversample=4) -> xarray.DataArray:
         big_aperture = self.diameter * 1.05
         x = np.arange(int(big_aperture.value) * oversample)
         x = x - x.shape[0] // 2

--- a/mocksipipeline/instrument/optics/aperture.py
+++ b/mocksipipeline/instrument/optics/aperture.py
@@ -69,11 +69,11 @@ class SlotAperture(AbstractAperture):
 
         # Lower part of slot
         r = np.sqrt((x - self.center_to_center_distance/2)**2 + y**2)
-        pinhole_lower = np.where(r < self.diameter / 2, 0, 1)
+        pinhole_lower = np.where(r < self.diameter/2, 0, 1)
 
         # Upper part of slot
         r = np.sqrt((x + self.center_to_center_distance/2)**2 + y**2)
-        pinhole_upper = np.where(r < self.diameter / 2, 0, 1)
+        pinhole_upper = np.where(r < self.diameter/2, 0, 1)
 
         # Middle rectangle
         x_cut = np.where(
@@ -83,11 +83,15 @@ class SlotAperture(AbstractAperture):
         rectangle = 0 ** rectangle
 
         mask = pinhole_lower * pinhole_upper * rectangle
-        return xarray.DataArray(
-            data=mask,
-            dims=["x", "y"],
-            coords={'x': (['x','y'], x), 'y': (['x','y'], y)},
-        )
+        x_coord = xarray.DataArray(data=x.value,
+                                   dims=['x','y'],
+                                   attrs={'unit': x.unit.to_string(format='fits')})
+        y_coord = xarray.DataArray(data=y.value,
+                                   dims=['x','y'],
+                                   attrs={'unit': y.unit.to_string(format='fits')})
+        return xarray.DataArray(data=mask,
+                                dims=["x", "y"],
+                                coords={'x': x_coord, 'y': y_coord})
 
     def __repr__(self):
         return f"""Slot Aperture
@@ -126,10 +130,7 @@ class CircularAperture(AbstractAperture):
         return xarray.DataArray(
             data=mask,
             dims=["x", "y"],
-            coords=dict(
-                x=(["x", "y"], x),
-                y=(["x", "y"], y),
-            ),
+            coords={'x': (["x", "y"], x), 'y': (["x", "y"], y)}
         )
 
     def __repr__(self):

--- a/mocksipipeline/instrument/optics/aperture.py
+++ b/mocksipipeline/instrument/optics/aperture.py
@@ -2,18 +2,42 @@
 Classes for configuring MOXSI apertures
 """
 import abc
+import pathlib
 
 import astropy.units as u
 import numpy as np
+import scipy
 import xarray
+from astropy.utils.data import get_pkg_data_filename, get_pkg_data_path
 
 __all__ = ['SlotAperture', 'CircularAperture']
+
+
+def _wfe2psf(wfe, oversample=8):
+    """
+    Adaptation of CCK Fourier optics code originally in IDL for converting wavefront errors into PSFs
+    """
+    shp = wfe.shape[0]  # probably assumes it's square, could be changed
+    waves = np.exp(2 * np.pi * wfe * 1j)
+    big_waves = np.zeros((shp * oversample, shp * oversample), dtype='complex')
+    big_waves[0:shp, 0:shp] = waves
+    psf = scipy.fft.fft2(big_waves, workers=-1)
+    psf = np.abs(psf) ** 2
+    psf /= psf.max()
+    psf = np.roll(psf, (shp // 2, shp // 2), axis=[0, 1])
+    psf = psf[0:shp, 0:shp]
+    return psf
 
 
 class AbstractAperture(abc.ABC):
     """
     An abstract base class for defining the geometry of a MOXSI aperture
     """
+
+    @property
+    @abc.abstractmethod
+    def name(self):
+        ...
 
     @property
     @abc.abstractmethod
@@ -25,6 +49,85 @@ class AbstractAperture(abc.ABC):
     @abc.abstractmethod
     def mask(self):
         ...
+
+    @u.quantity_input(wavelength=u.Angstrom, resolution=u.m)
+    def calculate_psf(self, wavelength, optical_design, resolution=1/8*u.micron, fft_oversample=4, save_psf=False):
+        """
+        Calculate wavelength-dependent PSF for a given optical design.
+
+        Parameters
+        ----------
+        wavelength
+        optical_design
+        resolution
+        fft_oversample
+        save_psf
+        """
+        # TODO: Add an option to read from a file--could save the file using the name of the optical design
+        # and the name of the aperture
+        wavelength = np.atleast_1d(wavelength)
+        mask = self.mask(resolution=resolution)
+        x = u.Quantity(mask.coords['x'].data, mask.coords['x'].attrs['unit'])
+        y = u.Quantity(mask.coords['y'].data, mask.coords['y'].attrs['unit'])
+        x_step = x[0, 1] - x[0, 0]
+        y_step = y[1, 0] - y[0, 0]
+        x_domain = x[0, -1] - x[0, 0]
+        f_number = (optical_design.focal_length/x_domain).to_value(u.dimensionless_unscaled)
+        # NOTE: The logic here is to multiple the wavefront errors by a large imaginary
+        # number so that wavefront errors can easily be tracked as they propagate through
+        # the system.
+        # NOTE: only the fresnel term depends on wavelength
+        wfe = mask.data * 1e9 * 1j
+        psfs = []
+        for wave in wavelength:
+            dx = wave * f_number / fft_oversample
+            fresnel_wfe = (x**2 + y**2)/(2*wave*optical_design.focal_length) + 0.j
+            wfe_total = wfe + fresnel_wfe.to_value(u.dimensionless_unscaled)
+            fresnel_psf = _wfe2psf(wfe_total, oversample=fft_oversample)
+            x_psf = (x / x_step * dx).to(x.unit)
+            y_psf = (y / y_step * dx).to(x.unit)
+            x_coord = xarray.DataArray(data=x_psf[0,:].value,
+                                       dims=['x'],
+                                       attrs={'unit': x_psf.unit.to_string(format='fits')})
+            y_coord = xarray.DataArray(data=y_psf[:,0].value,
+                                       dims=['y'],
+                                       attrs={'unit': y_psf.unit.to_string(format='fits')})
+            _psf = xarray.DataArray(data=fresnel_psf.T,
+                                    dims=['x', 'y'],
+                                    coords={'x': x_coord, 'y': y_coord})
+            psfs.append(_psf)
+
+        # NOTE: Interpolate to the DataArray corresponding to the smallest wavelength
+        # because it will have the highest resolution
+        psf_target = psfs[np.argmin(wavelength)]
+        wave_coord = xarray.DataArray(wavelength.value,
+                                      dims=['wavelength'],
+                                      attrs={'unit': wavelength.unit.to_string(format='fits')})
+        pixel_size_x = optical_design.pixel_size_x.to_value(psf_target.coords['x'].attrs['unit'])
+        pixel_size_y = optical_design.pixel_size_y.to_value(psf_target.coords['y'].attrs['unit'])
+        pixel_coord_x = psf_target.coords['x'] / pixel_size_x
+        pixel_coord_x.attrs['unit'] = 'pixel'
+        pixel_coord_y = psf_target.coords['y'] / pixel_size_y
+        pixel_coord_y.attrs['unit'] = 'pixel'
+        psf_cube = xarray.DataArray(
+            data=np.array([psf.interp_like(psf_target) for psf in psfs]),
+            dims=['wavelength', 'x', 'y'],
+            coords={'x': psf_target.coords['x'],
+                    'y': psf_target.coords['y'],
+                    'delta_pixel_x': pixel_coord_x,
+                    'delta_pixel_y': pixel_coord_y,
+                    'wavelength': wave_coord},
+        )
+        if save_psf:
+            data_dir = pathlib.Path(get_pkg_data_path('data', package='mocksipipeline.instrument.optics'))
+            psf_cube.to_netcdf(data_dir / f'psf_{optical_design.name}_{self.name}.nc')
+
+        return psf_cube
+
+    def get_psf(self, optical_design):
+        filename = get_pkg_data_filename(f'data/psf_{optical_design.name}_{self.name}.nc',
+                                         package='mocksipipeline.instrument.optics')
+        return xarray.open_dataarray(filename)
 
 
 class SlotAperture(AbstractAperture):
@@ -43,11 +146,16 @@ class SlotAperture(AbstractAperture):
         self.center_to_center_distance = center_to_center_distance
 
     @property
+    def name(self):
+        return f"slot_{self.center_to_center_distance.to_value('um'):.0f}"
+
+    @property
     @u.quantity_input
     def area(self) -> u.cm**2:
         return np.pi*(self.diameter/2)**2 + self.diameter*self.center_to_center_distance
 
-    def mask(self, oversample=8/u.micron):
+    @u.quantity_input(resolution=u.micron)
+    def mask(self, resolution=1*u.micron):
         """
         Create a boolean mask for the aperture relevant to this channel.
 
@@ -63,8 +171,12 @@ class SlotAperture(AbstractAperture):
         """
         # NOTE: Add 5% safety factor for margin on array size relative to aperture size
         aperture_size = (self.center_to_center_distance + self.diameter) * 1.05
-        n_x = int((aperture_size * oversample).to_value(u.dimensionless_unscaled))
-        x = np.linspace(-aperture_size/2, aperture_size/2, n_x, endpoint=True)
+        # NOTE: This is done this way because np.arange annoyingly does not play well
+        # with quantities
+        start = -aperture_size/2
+        stop = aperture_size/2
+        n_step = int(np.ceil(((stop - start) / resolution).to_value(u.dimensionless_unscaled)))
+        x = np.linspace(start, stop, n_step, endpoint=True)
         x, y = np.meshgrid(x, x)
 
         # Lower part of slot
@@ -96,6 +208,7 @@ class SlotAperture(AbstractAperture):
     def __repr__(self):
         return f"""Slot Aperture
 -----------------------------
+name: {self.name}
 diameter: {self.diameter}
 center to center distance: {self.center_to_center_distance}
 area: {self.area}
@@ -116,26 +229,39 @@ class CircularAperture(AbstractAperture):
         self.diameter = diameter
 
     @property
+    def name(self):
+        return f"circular_{self.diameter.to_value('um'):.0f}"
+
+    @property
     @u.quantity_input
     def area(self) -> u.cm**2:
         return np.pi*(self.diameter/2)**2
 
-    def mask(self, oversample=8/u.micron) -> xarray.DataArray:
+    def mask(self, resolution=1*u.micron) -> xarray.DataArray:
         # NOTE: Add 5% safety factor for margin on array size relative to aperture size
         aperture_size = self.diameter * 1.05
-        n_x = int((aperture_size * oversample).to_value(u.dimensionless_unscaled))
-        x = np.linspace(-aperture_size/2, aperture_size/2, n_x, endpoint=True)
+        # NOTE: This is done this way because np.arange annoyingly does not play well
+        # with quantities
+        start = -aperture_size/2
+        stop = aperture_size/2
+        n_step = int(np.ceil(((stop - start) / resolution).to_value(u.dimensionless_unscaled)))
+        x = np.linspace(start, stop, n_step, endpoint=True)
         x, y = np.meshgrid(x, x)
         mask = np.where(np.sqrt(x**2 + y**2)<self.diameter/2, 0, 1)
-        return xarray.DataArray(
-            data=mask,
-            dims=["x", "y"],
-            coords={'x': (["x", "y"], x), 'y': (["x", "y"], y)}
-        )
+        x_coord = xarray.DataArray(data=x.value,
+                                   dims=['x','y'],
+                                   attrs={'unit': x.unit.to_string(format='fits')})
+        y_coord = xarray.DataArray(data=y.value,
+                                   dims=['x','y'],
+                                   attrs={'unit': y.unit.to_string(format='fits')})
+        return xarray.DataArray(data=mask,
+                                dims=["x", "y"],
+                                coords={'x': x_coord, 'y': y_coord})
 
     def __repr__(self):
         return f"""Circular Aperture
 -------------------------
+name: {self.name}
 diameter: {self.diameter}
 area: {self.area}
 """

--- a/mocksipipeline/instrument/optics/aperture.py
+++ b/mocksipipeline/instrument/optics/aperture.py
@@ -144,7 +144,7 @@ class AbstractAperture(abc.ABC):
     def get_psf(self, optical_design):
         filename = get_pkg_data_filename(f'data/psf_{optical_design.name}_{self.name}.nc',
                                          package='mocksipipeline.instrument.optics')
-        return xarray.open_dataarray(filename)
+        return xarray.open_dataarray(filename, chunks={"wavelength": 1})
 
 
 class SlotAperture(AbstractAperture):

--- a/mocksipipeline/instrument/optics/aperture.py
+++ b/mocksipipeline/instrument/optics/aperture.py
@@ -5,6 +5,7 @@ import abc
 
 import astropy.units as u
 import numpy as np
+import xarray
 
 __all__ = ['SlotAperture', 'CircularAperture']
 
@@ -17,6 +18,11 @@ class AbstractAperture(abc.ABC):
     @abc.abstractproperty
     @u.quantity_input
     def area(self) -> u.cm ** 2:
+        ...
+
+    @abc.abstractproperty
+    @u.quantity_input
+    def mask(self) -> xarray.DataArray:
         ...
 
 
@@ -38,7 +44,52 @@ class SlotAperture(AbstractAperture):
     @property
     @u.quantity_input
     def area(self) -> u.cm ** 2:
-        return np.pi * (self.diameter/2) ** 2 + self.diameter * self.center_to_center_distance
+        return np.pi * (self.diameter / 2) ** 2 + self.diameter * self.center_to_center_distance
+
+    @property
+    def mask(self, oversample=8):
+        pinhole_diameter = self.diameter
+        center2center_distance = self.center_to_center_distance
+
+        aperture_size = center2center_distance * 1.2
+        x = np.linspace(-aperture_size/2, aperture_size / 2, num=int((aperture_size*oversample).value), endpoint=True)
+        x, y = np.meshgrid(x, x)
+
+        # shift coordinate system
+        x_shift = x - center2center_distance / 2
+
+        r = np.sqrt(x_shift * x_shift + y * y)
+        pinhole = np.ones_like(r).value
+        pinhole[r < pinhole_diameter / 2] = 0
+
+        # shift coordinate system
+        x_shift = x + center2center_distance / 2
+
+        r = np.sqrt(x_shift * x_shift + y * y)
+        pinhole2 = np.ones_like(r).value
+        pinhole2[r < pinhole_diameter / 2] = 0
+
+        x_cut = np.ones_like(r).value
+        y_cut = np.ones_like(r).value
+
+        x_cut *= x > -center2center_distance / 2
+        x_cut *= x < center2center_distance / 2
+
+        y_cut *= y > -pinhole_diameter / 2
+        y_cut *= y < pinhole_diameter / 2
+
+        rectangle = x_cut * y_cut
+        rectangle = 0 ** rectangle
+
+        mask = pinhole * pinhole2 * rectangle
+        return xarray.DataArray(
+            data=mask,
+            dims=["x", "y"],
+            coords=dict(
+                x=(["x", "y"], x),
+                y=(["x", "y"], y),
+            ),
+        )
 
     def __repr__(self):
         return f"""Slot Aperture
@@ -66,6 +117,27 @@ class CircularAperture(AbstractAperture):
     @u.quantity_input
     def area(self) -> u.cm ** 2:
         return np.pi * (self.diameter / 2) ** 2
+
+    @property
+    def mask(self, oversample=16) -> xarray.DataArray:
+        big_aperture = self.diameter * 1.05
+        x = np.arange(int(big_aperture.value) * oversample)
+        x = x - x.shape[0] // 2
+
+        x, y = np.meshgrid(x, x)
+
+        r = np.sqrt(x * x + y * y)
+        pinhole = np.ones_like(r)
+        pinhole[r < self.diameter.value / 2 * oversample] = 0
+
+        return xarray.DataArray(
+            data=pinhole,
+            dims=["x", "y"],
+            coords=dict(
+                x=(["x", "y"], x / oversample),
+                y=(["x", "y"], y / oversample),
+            ),
+        )
 
     def __repr__(self):
         return f"""Circular Aperture

--- a/mocksipipeline/instrument/optics/aperture.py
+++ b/mocksipipeline/instrument/optics/aperture.py
@@ -8,7 +8,7 @@ import astropy.units as u
 import numpy as np
 import scipy
 import xarray
-from astropy.utils.data import get_pkg_data_filename, get_pkg_data_path
+from astropy.utils.data import get_pkg_data_path
 
 __all__ = ['SlotAperture', 'CircularAperture']
 
@@ -140,9 +140,13 @@ class AbstractAperture(abc.ABC):
         return psf_cube
 
     def get_psf(self, optical_design):
-        filename = get_pkg_data_filename(f'data/psf_{optical_design.name}_{self.name}.nc',
-                                         package='mocksipipeline.instrument.optics')
-        return xarray.open_dataarray(filename, chunks={"wavelength": 1})
+        filename = f'psf_{optical_design.name}_{self.name}.nc'
+        data_dir = pathlib.Path(get_pkg_data_path('data', package='mocksipipeline.instrument.optics'))
+        if (filepath := data_dir / filename).is_file():
+            return xarray.open_dataarray(filepath, chunks={"wavelength": 1})
+        else:
+            msg = f'No PSF file found: {filename}. Calculate and save it with {self.__class__.__name__}.calculate_psf()'
+            return FileNotFoundError(msg)
 
 
 class SlotAperture(AbstractAperture):

--- a/mocksipipeline/instrument/optics/configuration.py
+++ b/mocksipipeline/instrument/optics/configuration.py
@@ -9,7 +9,7 @@ __all__ = ['short_design', 'long_design', 'short_as_built_design']
 
 
 short_design = OpticalDesign(
-    'short tube',
+    'short_tube',
     focal_length=19.5 * u.cm,
     grating_focal_length=19.5 * u.cm,
     grating_groove_spacing=1 / 5000 * u.mm,
@@ -17,7 +17,7 @@ short_design = OpticalDesign(
 )
 
 long_design = OpticalDesign(
-    'long tube',
+    'long_tube',
     focal_length=25.5 * u.cm,
     grating_focal_length=25.5 * u.cm,
     grating_groove_spacing=1 / 5000 * u.mm,
@@ -25,7 +25,7 @@ long_design = OpticalDesign(
 )
 
 short_as_built_design = OpticalDesign(
-    'short tube as-built',
+    'short_tube_as-built',
     focal_length=19.5 * u.cm,
     grating_focal_length=18.21 * u.cm,
     grating_groove_spacing=1 / 5000 * u.mm,

--- a/mocksipipeline/instrument/optics/configuration.py
+++ b/mocksipipeline/instrument/optics/configuration.py
@@ -18,16 +18,16 @@ short_design = OpticalDesign(
 
 long_design = OpticalDesign(
     'long_tube',
-    focal_length=25.5 * u.cm,
-    grating_focal_length=25.5 * u.cm,
-    grating_groove_spacing=1 / 5000 * u.mm,
-    grating_roll_angle=0 * u.deg,
+    focal_length=25.5*u.cm,
+    grating_focal_length=25.5*u.cm,
+    grating_groove_spacing=1/5000*u.mm,
+    grating_roll_angle=0*u.deg,
 )
 
 short_as_built_design = OpticalDesign(
     'short_tube_as-built',
-    focal_length=19.5 * u.cm,
-    grating_focal_length=18.21 * u.cm,
-    grating_groove_spacing=1 / 5000 * u.mm,
-    grating_roll_angle=0 * u.deg,
+    focal_length=20.8*u.cm,
+    grating_focal_length=19.5*u.cm,
+    grating_groove_spacing=1/5000*u.mm,
+    grating_roll_angle=0*u.deg,
 )

--- a/pipeline/config/config.yml
+++ b/pipeline/config/config.yml
@@ -10,3 +10,5 @@ exposure_time: 3600  # in s
 cadence: 3600  # in s
 apply_electron_conversion: True
 apply_gain_conversion: True
+include_psf: True
+include_charge_spreading: True

--- a/pipeline/workflow/scripts/project_intensity_cubes.py
+++ b/pipeline/workflow/scripts/project_intensity_cubes.py
@@ -1,6 +1,4 @@
 import astropy.units as u
-import scipy.ndimage
-from astropy.stats import gaussian_fwhm_to_sigma
 from astropy.wcs.utils import wcs_to_celestial_frame
 from overlappy.io import write_overlappogram
 
@@ -9,30 +7,20 @@ from mocksipipeline.modeling import (convolve_with_response,
                                      project_spectral_cube)
 from mocksipipeline.util import read_data_cube
 
-
-def apply_psf(cube, channel):
-    # FIXME: This is just a placeholder PSF calculation. Need to implement an actual
-    # convolution with a model PSF that more accurately captures the effect of the slot
-    # on the spatial resolution
-    # NOTE: By applying the PSF on the spectral cube, we are assuming that the pixel grid
-    # here is aligned with the pixel grid of the detector. The PSF FWHM has been carefully
-    # constructed to account for this. In general, we should figure out a way to define
-    # the PSF kernel on the zeroth order detector grid and transform it to this coordinate
-    # system.
-    psf_sigma = channel.aperture.psf_fwhm * gaussian_fwhm_to_sigma / channel.spatial_plate_scale
-    _ = scipy.ndimage.gaussian_filter(cube.data,
-                                      psf_sigma.to_value('pixel')[::-1],
-                                      axes=(1,2),
-                                      output=cube.data)
-    return cube
-
-
 if __name__ == '__main__':
     # Read in config options
     dt = float(snakemake.config['exposure_time']) * u.s
     interval = float(snakemake.config['cadence']) * u.s
     apply_electron_conversion = bool(snakemake.config['apply_electron_conversion'])
     apply_gain_conversion = bool(snakemake.config['apply_gain_conversion'])
+    include_psf = bool(snakemake.config['include_psf'])
+    include_charge_spreading = bool(snakemake.config['include_charge_spreading'])
+    if pointing_jitter := snakemake.config.get('pointing_jitter', None):
+        pointing_jitter = float(pointing_jitter) * u.arcsec
+    # Connect to scheduler if specified
+    if client_address := snakemake.config.get('scheduler_address', None):
+        import distributed
+        client = distributed.Client(address=client_address)
     # Load instrument configuration
     instrument_design = getattr(mocksipipeline.instrument.configuration, snakemake.config['instrument_design'])
     # Select channel
@@ -47,6 +35,9 @@ if __name__ == '__main__':
                                      wcs_to_celestial_frame(spec_cube.wcs).observer,
                                      dt=dt,
                                      interval=interval,
+                                     pointing_jitter=pointing_jitter,
+                                     include_psf=include_psf,
+                                     include_charge_spreading=include_charge_spreading,
                                      apply_gain_conversion=apply_gain_conversion,
                                      apply_electron_conversion=apply_electron_conversion)
     # Save to file

--- a/pipeline/workflow/scripts/project_intensity_cubes.py
+++ b/pipeline/workflow/scripts/project_intensity_cubes.py
@@ -41,9 +41,6 @@ if __name__ == '__main__':
     spec_cube = read_data_cube(snakemake.input[0])
     # Convolve with instrument response function
     instr_cube = convolve_with_response(spec_cube, channel, include_gain=False)
-    # Apply channel-dependent PSF
-    # PSF convolution calculation goes here
-    instr_cube = apply_psf(instr_cube, channel)
     # Remap spectral cube
     det_cube = project_spectral_cube(instr_cube,
                                      channel,


### PR DESCRIPTION
Fixes #35 
Fixes #40 

This PR implements "jitter" in photon position in pixel space on the detector due to both 1) the wavelength-dependent PSF and 2) charge spreading.

This PR also

- Implements methods for computing and retrieving the wavelength-dependent PSFs
- Adds an instrument configuration for CDR
- Updates the as-built design
